### PR TITLE
Implement Qobuz token refresh & metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ fla get qobuz <track_id> output.flac
    fla set path --library ~/Music --cache ~/.cache/flaccid
    ```
 
+   The Qobuz plugin reads `QOBUZ_APP_ID` and `QOBUZ_TOKEN` from the
+   environment. If the token is invalid it will be refreshed automatically
+   using the stored credentials.
+
 ## Usage
 
 ### Library Scanning

--- a/src/flaccid/plugins/qobuz.py
+++ b/src/flaccid/plugins/qobuz.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Any, Optional
+import contextlib
 
 import aiohttp
 import keyring
@@ -35,15 +36,43 @@ class QobuzPlugin(MetadataProviderPlugin):
             self.session = None
 
     async def authenticate(self) -> None:
+        """Ensure a valid authentication token is available."""
         if not self.token:
             self.token = keyring.get_password("flaccid_qobuz", "token")
-        # Real implementation would refresh token if needed
+        if not self.token:
+            await self._refresh_token()
+
+    async def _refresh_token(self) -> None:
+        """Refresh the stored authentication token."""
+        assert self.session is not None, "Session not initialized"
+        async with self.session.get(
+            self.BASE_URL + "login/refresh",
+            params={"app_id": self.app_id, "user_auth_token": self.token},
+        ) as resp:
+            data = await resp.json()
+        token = data.get("user_auth_token")
+        if not token:
+            raise RuntimeError("Failed to refresh Qobuz token")
+        self.token = token
+        try:
+            keyring.set_password("flaccid_qobuz", "token", token)
+        except Exception:
+            pass
 
     async def _request(self, endpoint: str, **params: Any) -> Any:
+        """Perform an API request and refresh the token on 401 responses."""
         assert self.session is not None, "Session not initialized"
         params.setdefault("app_id", self.app_id)
+        if self.token:
+            params.setdefault("user_auth_token", self.token)
         async with self.session.get(self.BASE_URL + endpoint, params=params) as resp:
-            return await resp.json()
+            data = await resp.json()
+        if resp.status == 401:
+            await self._refresh_token()
+            params["user_auth_token"] = self.token
+            async with self.session.get(self.BASE_URL + endpoint, params=params) as retry:
+                return await retry.json()
+        return data
 
     async def search_track(self, query: str) -> Any:
         await self.authenticate()
@@ -54,22 +83,50 @@ class QobuzPlugin(MetadataProviderPlugin):
     async def get_track(self, track_id: str) -> TrackMetadata:
         await self.authenticate()
         data = await self._request("track/get", track_id=track_id)
+
+        album_info = data.get("album", {})
+        year = None
+        date_str = album_info.get("release_date_original") or data.get("year")
+        if isinstance(date_str, str) and date_str:
+            with contextlib.suppress(ValueError):
+                year = int(date_str.split("-")[0])
+
         return TrackMetadata(
             title=data.get("title", ""),
-            artist=data.get("artist", ""),
-            album=data.get("album", ""),
-            track_number=int(data.get("track_number", 0)),
-            disc_number=int(data.get("disc_number", 0)),
-            year=data.get("year"),
+            artist=data.get("performer", {}).get("name") or data.get("artist", ""),
+            album=album_info.get("title", data.get("album", "")),
+            track_number=int(data.get("track_number", data.get("trackNumber", 0))),
+            disc_number=int(data.get("disc_number", data.get("media_number", 0))),
+            year=year,
+            isrc=data.get("isrc"),
+            art_url=album_info.get("image"),
         )
 
     async def get_album(self, album_id: str) -> AlbumMetadata:
         await self.authenticate()
         data = await self._request("album/get", album_id=album_id)
+
+        year = None
+        date_str = data.get("release_date_original") or data.get("year")
+        if isinstance(date_str, str) and date_str:
+            with contextlib.suppress(ValueError):
+                year = int(date_str.split("-")[0])
+
+        artist = data.get("artist")
+        if isinstance(artist, dict):
+            artist = artist.get("name", "")
+
+        image = data.get("image")
+        if isinstance(image, dict):
+            cover_url = image.get("large") or image.get("small")
+        else:
+            cover_url = image
+
         return AlbumMetadata(
             title=data.get("title", ""),
-            artist=data.get("artist", ""),
-            year=data.get("year"),
+            artist=artist or "",
+            year=year,
+            cover_url=cover_url,
         )
 
     async def search_album(self, query: str) -> Any:

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +17,28 @@ async def test_qobuz_plugin_auth(monkeypatch):
         async with QobuzPlugin() as plugin:
             await plugin.authenticate()
             assert plugin.token == "secret"
+
+
+@pytest.mark.asyncio
+async def test_qobuz_env_token(monkeypatch):
+    monkeypatch.setattr("keyring.get_password", lambda service, user: "ignored")
+    with patch.dict(os.environ, {"QOBUZ_TOKEN": "envtok", "QOBUZ_APP_ID": "id"}):
+        async with QobuzPlugin() as plugin:
+            await plugin.authenticate()
+            assert plugin.token == "envtok"
+
+
+@pytest.mark.asyncio
+async def test_qobuz_refresh(monkeypatch):
+    async def fake_refresh(self):
+        self.token = "fresh"
+
+    monkeypatch.setattr("keyring.get_password", lambda service, user: None)
+    monkeypatch.setattr(QobuzPlugin, "_refresh_token", fake_refresh)
+    with patch.dict(os.environ, {"QOBUZ_APP_ID": "id"}):
+        async with QobuzPlugin() as plugin:
+            await plugin.authenticate()
+            assert plugin.token == "fresh"
 
 
 def test_track_metadata_dataclass():
@@ -61,3 +84,46 @@ async def test_lyrics_plugin(tmp_path, monkeypatch):
         monkeypatch.setattr(plugin.session, "get", fake_get)
         lyrics = await plugin.get_lyrics("artist", "song")
         assert lyrics == "la la"
+
+
+@pytest.mark.asyncio
+async def test_qobuz_metadata(monkeypatch):
+    """Ensure album and track metadata are parsed."""
+
+    track_data = {
+        "title": "Song",
+        "performer": {"name": "Artist"},
+        "album": {
+            "title": "Album",
+            "release_date_original": "2024-01-01",
+            "image": "cover.jpg",
+        },
+        "track_number": 1,
+        "media_number": 1,
+    }
+
+    album_data = {
+        "title": "Album",
+        "artist": {"name": "Artist"},
+        "release_date_original": "2024-01-01",
+        "image": {"large": "cover.jpg"},
+    }
+
+    async def fake_request(self, endpoint: str, **params: Any):
+        if endpoint == "track/get":
+            return track_data
+        return album_data
+
+    monkeypatch.setattr(QobuzPlugin, "_request", fake_request)
+    plugin = QobuzPlugin(app_id="id", token="t")
+    async with plugin:
+        track = await plugin.get_track("1")
+        assert track.title == "Song"
+        assert track.artist == "Artist"
+        assert track.album == "Album"
+        assert track.year == 2024
+        album = await plugin.get_album("2")
+        assert album.title == "Album"
+        assert album.artist == "Artist"
+        assert album.year == 2024
+        assert album.cover_url == "cover.jpg"


### PR DESCRIPTION
## Summary
- refresh the Qobuz authentication token automatically
- parse nested album and track metadata from Qobuz responses
- document new environment variables in README
- extend plugin unit tests for token refresh and metadata parsing

## Testing
- `poetry run flake8 src tests --ignore=E203,E401,E402,F401,F841`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68723c8ea6f88326a0e0b3be4080377e